### PR TITLE
fix(bullet-generator): ignore and replace a bullet starting `-`

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -42,7 +42,7 @@ let bulletPress = (string)=>{
   
   let replacements = [
     [/\s*--\s*/gi, '--'],   // 'asdf -- abcd' >>> 'asdf--abcd'
-    [/^\s+/gi, '- '],       // ' asdf' >>> '- asdf'
+    [/^\s*-?\s*/gi, '- '],       // ' asdf' >>> '- asdf'
     [/\s+$/gi, ''],         // 'asdf ' >>> 'asdf'
     [/\s*\/\s*/gi, '/'], 
     [/\s*,/gi, ','],


### PR DESCRIPTION
Since many times bullets are copied and pasted into the tool, make sure that the user doesn't have to always delete the initial `- ` before it will work for them.